### PR TITLE
Add Python 3 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# OctoPrint-EditorCollection
+### This plugin is for putting Salandora's editor plugins onto one page
+This plugin moves the Editor’s from Salandora onto a single Page.

--- a/octoprint_editorcollection/__init__.py
+++ b/octoprint_editorcollection/__init__.py
@@ -36,6 +36,7 @@ class EditorCollectionPlugin(octoprint.plugin.TemplatePlugin):
 # ("OctoPrint-PluginSkeleton"), you may define that here. Same goes for the other metadata derived from setup.py that
 # can be overwritten via __plugin_xyz__ control properties. See the documentation for that.
 __plugin_name__ = "Editor Collection"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
 	global __plugin_implementation__

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_%s" % plugin_identifier
 plugin_name = "OctoPrint-EditorCollection"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.2"
+plugin_version = "0.1.3"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
As Python 2 has now officially reached End Of Life (https://www.python.org/doc/sunset-python-2/), and Octoprint supports Python 3 as of Release 1.4.0, all plugins are encouraged to add Python 3 compatibility, which is what I have done in this pull request.
To accomplish this, I have made the following changes:

- Added the plugin property __plugin_pythoncompat__ = ">=2.7,<4"
- Updated the plugin version to 0.1.3

This update has being tested and confirmed to work in both Python 2.7 and 3.7 using Octoprint 1.4.0 running on Octopi 0.17.0

Cheers,
Alex.